### PR TITLE
:globe_with_meridians: Fix french dictionary not being translated

### DIFF
--- a/dictionaries/fr.dict.combodo-my-account-user-info.php
+++ b/dictionaries/fr.dict.combodo-my-account-user-info.php
@@ -7,7 +7,7 @@
  */
 
 Dict::Add('FR FR', 'French', 'Français', array(
-	'MyAccount:UserInfo:Tab:Title' => 'My User Information',
-	'MyAccount:SubTitle:user' => 'My user',
-	'MyAccount:SubTitle:contact' => 'My contact',
+	'MyAccount:UserInfo:Tab:Title' => 'Mes informations personnelles',
+	'MyAccount:SubTitle:user' => 'Mon utilisateur',
+	'MyAccount:SubTitle:contact' => 'Mon contact',
 ));


### PR DESCRIPTION
## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thead / Another PR / Combodo ticket? | No
| Type of change?                                               | Translations


## Symptom (bug)
Some entries of the new "My account" page in the backoffice are not translated in french:
![image](https://github.com/user-attachments/assets/a256bbee-844e-40fd-8991-d3598332bb04)


## Reproduction procedure (bug)
1. On iTop 3.2.1
2. With module version 1.0.0
3. With PHP 8.1.3
4. Log in the backoffice
5. Ensure user language is set to _french_
6. Go on the _My account_ page
7. See that most titles / sections are not translated


## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] I have tested all changes I made on an iTop instance
- [X] Would a unit test be relevant and have I added it?
- [X] Is the PR clear and detailed enough so anyone can understand digging in the code?

## Checklist of things to do before PR is ready to merge
